### PR TITLE
Upgrade to elm 0.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+elm-stuff

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "Date.Format"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Date/Format.elm
+++ b/src/Date/Format.elm
@@ -1,4 +1,4 @@
-module Date.Format (format, formatISO8601) where
+module Date.Format exposing (format, formatISO8601)
 
 {-| Format strings for dates.
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,8 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/tests/test.elm
+++ b/tests/test.elm
@@ -1,4 +1,4 @@
-module Main (..) where
+module Main exposing (..)
 
 {- A simple test an example of the library.
 Does not test every option, you can submit PRs for that.
@@ -6,7 +6,7 @@ Does not test every option, you can submit PRs for that.
 
 import Date
 import Date.Format
-import ElmTest exposing (test, Test, suite, assertEqual, elementRunner)
+import ElmTest exposing (test, Test, suite, assertEqual, runSuiteHtml)
 
 
 -- test name, expected value, format string
@@ -52,4 +52,4 @@ tests =
 
 
 main =
-  elementRunner tests
+  runSuiteHtml tests


### PR DESCRIPTION
Also, noticed that https://github.com/mgold/elm-date-format/pull/10 is true, JavaScript adds your timezone by default, so the expected values would need to be constructed rather than be hardcoded to fix this.