### PR TITLE
Localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The input `String` may contain any of the following substrings, which will be ex
 * `%S` - Second of the minute, zero-padded
 * `%%` - literal `%`
 
+## Localization
+
+`Date.Format` also exports `localFormat : Date.Local.Local -> String -> Date.Date -> String`.
+This function allows to add a localization record as specified in `Date.Local`.
+It can be used to display local terms for week days, months, and AM or PM.
+
 ## Contributing
 
 Pull requests are welcome! Note that in addition to adding a new letter to the

--- a/src/Date/Format.elm
+++ b/src/Date/Format.elm
@@ -1,16 +1,17 @@
-module Date.Format exposing (format, formatISO8601)
+module Date.Format exposing (format, localFormat, formatISO8601)
 
 {-| Format strings for dates.
 
-@docs format, formatISO8601
+@docs format, localFormat, formatISO8601
 -}
 
 import Date
 import Regex
-import String exposing (padLeft, right)
+import String exposing (padLeft, right, toUpper)
 import Maybe exposing (andThen, withDefault)
 import List exposing (head, tail)
 
+import Date.Local exposing (Local, international)
 
 re : Regex.Regex
 re =
@@ -23,7 +24,16 @@ list of accepted formatters.
 -}
 format : String -> Date.Date -> String
 format s d =
-    Regex.replace Regex.All re (formatToken d) s
+  localFormat international s d
+
+
+{-| Use a localization record and a format string to format a date. See the
+[README](https://github.com/mgold/elm-date-format/blob/master/README.md) for a
+list of accepted formatters.
+-}
+localFormat : Local -> String -> Date.Date -> String
+localFormat loc s d =
+    Regex.replace Regex.All re (formatToken loc d) s
 
 
 {-| Formats a UTC date acording to
@@ -35,8 +45,8 @@ formatISO8601 =
     format "%Y-%m-%dT%H:%M:%SZ"
 
 
-formatToken : Date.Date -> Regex.Match -> String
-formatToken d m =
+formatToken : Local -> Date.Date -> Regex.Match -> String
+formatToken loc d m =
     let
         symbol =
             case m.submatches of
@@ -60,10 +70,10 @@ formatToken d m =
                 d |> Date.month |> monthToInt |> toString |> padLeft 2 '0'
 
             "B" ->
-                d |> Date.month |> monthToFullName
+                d |> Date.month |> monthToWord loc.date.months
 
             "b" ->
-                d |> Date.month |> toString
+                d |> Date.month |> monthToWord loc.date.monthsAbbrev
 
             "d" ->
                 d |> Date.day |> padWith '0'
@@ -72,10 +82,10 @@ formatToken d m =
                 d |> Date.day |> padWith ' '
 
             "a" ->
-                d |> Date.dayOfWeek |> toString
+                d |> Date.dayOfWeek |> dayOfWeekToWord loc.date.wdaysAbbrev
 
             "A" ->
-                d |> Date.dayOfWeek |> fullDayOfWeek
+                d |> Date.dayOfWeek |> dayOfWeekToWord loc.date.wdays
 
             "H" ->
                 d |> Date.hour |> padWith '0'
@@ -91,15 +101,15 @@ formatToken d m =
 
             "p" ->
                 if Date.hour d < 12 then
-                    "AM"
+                    toUpper loc.time.am
                 else
-                    "PM"
+                    toUpper loc.time.pm
 
             "P" ->
                 if Date.hour d < 12 then
-                    "am"
+                    loc.time.am
                 else
-                    "pm"
+                    loc.time.pm
 
             "M" ->
                 d |> Date.minute |> padWith '0'
@@ -150,67 +160,67 @@ monthToInt m =
             12
 
 
-monthToFullName m =
+monthToWord loc m =
     case m of
         Date.Jan ->
-            "January"
+            loc.jan
 
         Date.Feb ->
-            "February"
+            loc.feb
 
         Date.Mar ->
-            "March"
+            loc.mar
 
         Date.Apr ->
-            "April"
+            loc.apr
 
         Date.May ->
-            "May"
+            loc.may
 
         Date.Jun ->
-            "June"
+            loc.jun
 
         Date.Jul ->
-            "July"
+            loc.jul
 
         Date.Aug ->
-            "August"
+            loc.aug
 
         Date.Sep ->
-            "September"
+            loc.sep
 
         Date.Oct ->
-            "October"
+            loc.oct
 
         Date.Nov ->
-            "November"
+            loc.nov
 
         Date.Dec ->
-            "December"
+            loc.dec
 
 
-fullDayOfWeek dow =
+dayOfWeekToWord loc dow =
     case dow of
         Date.Mon ->
-            "Monday"
+            loc.mon
 
         Date.Tue ->
-            "Tuesday"
+            loc.tue
 
         Date.Wed ->
-            "Wednesday"
+            loc.wed
 
         Date.Thu ->
-            "Thursday"
+            loc.thu
 
         Date.Fri ->
-            "Friday"
+            loc.fri
 
         Date.Sat ->
-            "Saturday"
+            loc.sat
 
         Date.Sun ->
-            "Sunday"
+            loc.sun
 
 
 mod12 h =

--- a/src/Date/Local.elm
+++ b/src/Date/Local.elm
@@ -1,5 +1,7 @@
 module Date.Local exposing (..)
 
+import Dict exposing (Dict)
+
 {-| Record to store localized time format.
 
 Time zones and default formats are not implemented,
@@ -12,15 +14,15 @@ type alias Local =
     , monthsAbbrev : Months
     , wdays : WeekDays
     , wdaysAbbrev : WeekDays
-    , defaultFormat : Maybe String
+    , defaultFormat : Maybe String -- for %x
     }
   , time :
     { am : String
     , pm : String
-    , defaultFormat : Maybe String
+    , defaultFormat : Maybe String -- for %X
     }
-  , timeZones : Maybe TimeZones
-  , defaultFormat : Maybe String
+  , timeZones : Maybe TimeZones -- for %Z
+  , defaultFormat : Maybe String -- for %c
   }
 
 type alias Months =
@@ -48,7 +50,8 @@ type alias WeekDays =
   , sun : String
   }
 
-type alias TimeZones = Never
+-- Maps from %z type string (+hhmm or -hhmm) to timezone name or abbreviation.
+type alias TimeZones = Dict String String
 
 international : Local
 international =

--- a/src/Date/Local.elm
+++ b/src/Date/Local.elm
@@ -1,0 +1,111 @@
+module Date.Local exposing (..)
+
+{-| Record to store localized time format.
+
+Time zones and default formats are not implemented,
+but included to avoid possible version conflicts in the future.
+-}
+
+type alias Local =
+  { date :
+    { months : Months
+    , monthsAbbrev : Months
+    , wdays : WDays
+    , wdaysAbbrev : WDays
+    , defaultFormat : Maybe String
+    }
+  , time :
+    { am : String
+    , pm : String
+    , defaultFormat : Maybe String
+    }
+  , timeZones : Maybe TimeZones
+  , defaultFormat : Maybe String
+  }
+
+type alias Months =
+  { jan : String
+  , feb : String
+  , mar : String
+  , apr : String
+  , may : String
+  , jun : String
+  , jul : String
+  , aug : String
+  , sep : String
+  , oct : String
+  , nov : String
+  , dec : String
+  }
+
+type alias WDays =
+  { mon : String
+  , tue : String
+  , wed : String
+  , thu : String
+  , fri : String
+  , sat : String
+  , sun : String
+  }
+
+type alias TimeZones = Never
+
+international : Local
+international =
+  { date =
+    { months =
+      { jan = "January"
+      , feb = "February"
+      , mar = "March"
+      , apr = "April"
+      , may = "May"
+      , jun = "June"
+      , jul = "July"
+      , aug = "August"
+      , sep = "September"
+      , oct = "October"
+      , nov = "November"
+      , dec = "December"
+      }
+    , monthsAbbrev =
+      { jan = "Jan"
+      , feb = "Feb"
+      , mar = "Mar"
+      , apr = "Apr"
+      , may = "May"
+      , jun = "Jun"
+      , jul = "Jul"
+      , aug = "Aug"
+      , sep = "Sep"
+      , oct = "Oct"
+      , nov = "Nov"
+      , dec = "Dec"
+      }
+    , wdays =
+      { mon = "Monday"
+      , tue = "Tuesday"
+      , wed = "Wednesday"
+      , thu = "Thursday"
+      , fri = "Friday"
+      , sat = "Saturday"
+      , sun = "Sunday"
+      }
+    , wdaysAbbrev =
+      { mon = "Mon"
+      , tue = "Tue"
+      , wed = "Wed"
+      , thu = "Thu"
+      , fri = "Fri"
+      , sat = "Sat"
+      , sun = "Sun"
+      }
+    , defaultFormat = Nothing
+    }
+  , time =
+    { am = "am"
+    , pm = "pm"
+    , defaultFormat = Nothing
+    }
+  , timeZones = Nothing
+  , defaultFormat = Nothing
+  }

--- a/src/Date/Local.elm
+++ b/src/Date/Local.elm
@@ -10,8 +10,8 @@ type alias Local =
   { date :
     { months : Months
     , monthsAbbrev : Months
-    , wdays : WDays
-    , wdaysAbbrev : WDays
+    , wdays : WeekDays
+    , wdaysAbbrev : WeekDays
     , defaultFormat : Maybe String
     }
   , time :
@@ -38,7 +38,7 @@ type alias Months =
   , dec : String
   }
 
-type alias WDays =
+type alias WeekDays =
   { mon : String
   , tue : String
   , wed : String


### PR DESCRIPTION
I added a new function `localFormat` to which you can pass a record with localization strings.
This is useful for the output of `%b`, `%B`, `%a`, and `%A`, because the words for week days and months may be different in languages other than English.

I decided on a record because this makes it easier to add additional languages later, e.g. by reading them from a json file. I was torn about the question whether to simply use the rails format for date localization. This would make it easier to just pass the localization into elm, without further modification. I decided against it because the rails format saves months and week days in arrays, which would require additional input validation to ensure that they are long enough.

If you have any suggestions for changes in the localization record, I'd be very happy to discuss them. Nothing is worse than specifying an API and later being forced to change it because I forgot to handle a case :)