### PR TITLE
Add support for padding modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,21 @@ Create format strings for dates in the Elm programming language.
 
 The module `Date.Format` exports `format : String -> Date.Date -> String`.
 The `Date` refers to Elm's standard [Date library](http://package.elm-lang.org/packages/elm-lang/core/latest/Date).
-The input `String` may contain any of the following substrings, which will be expanded to parts of the date.
+The input `String` may contain any of the following directives, which will be expanded to parts of the date.
+
+A directive consists of a percent (%) character, zero or more flags and a conversion specifier as follows.
+
+```
+%<flags><conversion>
+```
+
+Flags:
+
+* `-` - don't pad a numerical output
+* `_` - use spaces for padding
+* `0` - use zeros for padding
+
+Format directives:
 
 * `%Y` - 4 digit year
 * `%y` - 2 digit year

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -6,11 +6,11 @@ module Tests exposing (all)
 
 import Date
 import Date.Format
+import Expect
+import String exposing (join, padLeft)
+import Test exposing (..)
 import Time
 import Time.Format
-import String exposing (padLeft, join)
-import Expect
-import Test exposing (..)
 
 
 -- test name, expected value, format string
@@ -37,6 +37,7 @@ dateTestData =
     , ( "time", expectedTime, "%I:%M:%S %p" )
     , ( "time no spaces", expectedTimeNoSpace, "%H%M%S" )
     , ( "literal %", expectedTimeWithLiteral, "%H%%%M" )
+    , ( "padding modifiers", "08|8| 8|08", "%m|%-m|%_m|%0m" )
     ]
 
 
@@ -66,7 +67,7 @@ expectedFullTimeColons =
 
 
 expectedTime =
-    (join ":" [ sampleHour, sampleMinute, sampleMinute ])
+    join ":" [ sampleHour, sampleMinute, sampleMinute ]
         ++ (case Date.hour sampleDate < 12 of
                 True ->
                     " AM"
@@ -90,7 +91,7 @@ sampleTime =
 
 pad : Int -> String
 pad =
-    toString >> (padLeft 2 '0')
+    toString >> padLeft 2 '0'
 
 
 sampleHour : String


### PR DESCRIPTION
Hi there, I've bumped into a case where I'd rather not have the padding, so I looked up the [Ruby doc](https://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime) and introduced a couple of padding flags modifiers to this package. All the other unrelated changes were done by `elm-format`.