### PR TITLE
Added milliseconds as %L

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Format directives:
 * `%P` - am or pm
 * `%M` - Minute of the hour, zero-padded
 * `%S` - Second of the minute, zero-padded
+* `%L` - Millisecond of the second, zero-padded
 * `%%` - literal `%`
 
 ## Localization

--- a/src/Date/Format.elm
+++ b/src/Date/Format.elm
@@ -16,13 +16,14 @@ import String exposing (padLeft, right, toUpper)
 
 re : Regex.Regex
 re =
-    Regex.regex "%(_|-|0)?(%|Y|y|m|B|b|d|e|a|A|H|k|I|l|p|P|M|S)"
+    Regex.regex "%(_|-|0)?(%|Y|y|m|B|b|d|e|a|A|H|k|I|l|L|p|P|M|S)"
 
 
 type Padding
     = NoPadding
     | Space
     | Zero
+    | ZeroThreeDigits
 
 
 {-| Use a format string to format a date. See the
@@ -132,6 +133,9 @@ formatToken loc d m =
 
         "S" ->
             d |> Date.second |> padWith (withDefault Zero padding)
+
+        "L" ->
+            d |> Date.millisecond |> padWith (withDefault ZeroThreeDigits padding)
 
         _ ->
             ""
@@ -260,6 +264,9 @@ padWith padding =
 
                 Zero ->
                     padLeft 2 '0'
+
+                ZeroThreeDigits ->
+                    padLeft 3 '0'
 
                 Space ->
                     padLeft 2 ' '

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -47,6 +47,7 @@ timeTestData =
     , ( "literal %", expectedTimeWithLiteral, "%H%%%M" )
     , ( "time colons", expectedTimeColons, "%H:%M" )
     , ( "time full colons", expectedFullTimeColons, "%H:%M:%S" )
+    , ( "time with milliseconds", expectedTimeWithMilliSeconds, "%H:%M:%S:%L" )
     ]
 
 
@@ -66,6 +67,10 @@ expectedFullTimeColons =
     join ":" [ sampleHour, sampleMinute, sampleSecond ]
 
 
+expectedTimeWithMilliSeconds =
+    join ":" [ sampleHour, sampleMinute, sampleSecond, sampleMilliSecond ]
+
+
 expectedTime =
     join ":" [ sampleHour, sampleMinute, sampleMinute ]
         ++ (case Date.hour sampleDate < 12 of
@@ -79,9 +84,7 @@ expectedTime =
 
 sampleDate : Date.Date
 sampleDate =
-    "2014-08-12T04:53:53Z"
-        |> Date.fromString
-        |> Result.withDefault (Date.fromTime 1.407833631116e12)
+    Date.fromTime 1407819233012
 
 
 sampleTime : Time.Time
@@ -89,27 +92,33 @@ sampleTime =
     Date.toTime sampleDate
 
 
-pad : Int -> String
-pad =
-    toString >> padLeft 2 '0'
+pad : Int -> Int -> String
+pad n =
+    toString >> padLeft n '0'
 
 
 sampleHour : String
 sampleHour =
     Date.hour sampleDate
-        |> pad
+        |> pad 2
 
 
 sampleMinute : String
 sampleMinute =
     Date.minute sampleDate
-        |> pad
+        |> pad 2
 
 
 sampleSecond : String
 sampleSecond =
     Date.second sampleDate
-        |> pad
+        |> pad 2
+
+
+sampleMilliSecond : String
+sampleMilliSecond =
+    Date.millisecond sampleDate
+        |> pad 3
 
 
 formatSampleDate : String -> String


### PR DESCRIPTION
I made the changes to add milliseconds. The regex is the proposed `%L`.

Some details towards the changes I made: Milliseconds are three digit numbers and the padding had to be adapted. I'm not to sure about the generation of tests. I think this style is possibly error prone, because implementation is used to generate sample data and results. Could be an option to rewrite the tests and use  hardcoded dates and corner cases combined with fuzz tests instead.

**Update:** Thinking about it, the expectations depending on implementation are probably done to solve the issue where date tests depend on the time zone of the system?

I reduced the code block underneath to use `Date.fromTime` only. I think its for the better because the two mentioned dates (string and result default) weren't describing the same timestamp.

```elm
sampleDate : Date.Date
sampleDate =
    "2014-08-12T04:53:53Z"
        |> Date.fromString
        |> Result.withDefault (Date.fromTime 1.407833631116e12)
```
```js
new Date("2014-08-12T04:53:53Z") - new Date(1.407833631116e12)
-14398116
```

Closes #23 